### PR TITLE
perf(stats rows): optimize query for stats rows

### DIFF
--- a/admin/class-rate-my-post-admin.php
+++ b/admin/class-rate-my-post-admin.php
@@ -1131,9 +1131,18 @@ class Rate_My_Post_Admin {
 	private function stats_rows() {
 		$rated_posts = array();
 		$args = array(
-			 'fields'          => 'ids',
-			 'post_type'       => $this->define_post_types(),
-			 'posts_per_page'  => -1
+			 'fields'                 => 'ids',
+			 'post_type'              => $this->define_post_types(),
+			 'posts_per_page'         => -1,
+			 'no_found_rows'          => true,
+			 'update_post_term_cache' => false,
+			 'meta_query'             => array(
+				array(
+					'key'     => 'rmp_vote_count',
+					'value'   => 0,
+					'compare' => '>'
+				)
+			 )
 		);
 		$the_query = new WP_Query( $args );
 		// The Loop

--- a/rate-my-post/admin/class-rate-my-post-admin.php
+++ b/rate-my-post/admin/class-rate-my-post-admin.php
@@ -1131,9 +1131,18 @@ class Rate_My_Post_Admin {
 	private function stats_rows() {
 		$rated_posts = array();
 		$args = array(
-			 'fields'          => 'ids',
-			 'post_type'       => $this->define_post_types(),
-			 'posts_per_page'  => -1
+			 'fields'                 => 'ids',
+			 'post_type'              => $this->define_post_types(),
+			 'posts_per_page'         => -1,
+			 'no_found_rows'          => true,
+			 'update_post_term_cache' => false,
+			 'meta_query'             => array(
+				array(
+					'key'     => 'rmp_vote_count',
+					'value'   => 0,
+					'compare' => '>'
+				)
+			 )
 		);
 		$the_query = new WP_Query( $args );
 		// The Loop


### PR DESCRIPTION
When WordPress db has a huge number of post, the function stats_rows may generate a Fatal Error caused by memory leak. To solve this problem i edited the query to get only posts with at least one vote.
I also added two properties to optimize the query.

no_found_rows is useful when pagination is not needed, update_post_term_cache when taxonomy terms are not used.